### PR TITLE
Allow run file specs to work with nested apps

### DIFF
--- a/src/utils/toSpecPath.ts
+++ b/src/utils/toSpecPath.ts
@@ -1,11 +1,13 @@
 export default function toSpecPath(filePath: string, pattern: string): string {
-  let [first, ...rest] = filePath.split("/");
-
-  if (filePath.indexOf(`_${pattern}.rb`) > -1 || first === pattern) {
+  if (filePath.indexOf(`_${pattern}.rb`) > -1) {
     return filePath;
-  } else {
-    let middle = rest.slice(0, rest.length - 1);
-    let filename = rest[rest.length - 1];
-    return [pattern, ...middle, filename.replace(".rb", `_${pattern}.rb`)].join("/");
   }
+
+  let path = filePath.split("/");
+  let railsRoot = path.indexOf("app");
+  path[railsRoot] = pattern;
+
+  let filename = path[path.length - 1];
+  let specFile = filename.replace(".rb", `_${pattern}.rb`);
+  return [...path.slice(0, path.length - 1), specFile].join("/");
 }

--- a/test/utils/toSpecPath.test.ts
+++ b/test/utils/toSpecPath.test.ts
@@ -20,4 +20,11 @@ suite("toSpecPath", () => {
       toSpecPath("spec/controllers/namespaces/admin/test_controller_spec.rb", "spec")
     );
   });
+
+  test("Converting nested rails root", () => {
+    assert.equal(
+      "core/spec/controllers/test_controller_spec.rb",
+      toSpecPath("core/app/controllers/test_controller.rb", "spec")
+    );
+  });
 });


### PR DESCRIPTION
This allows large projects with multiple `app` directories (e.g rails engines etc) to work. It introduces the assumption that the rails root is called "app", and that this may not be the first entry in the path.

Implements: https://github.com/noku/rails-run-spec-vscode/issues/NNNN

## Summary

> ⚠️ **TBD**: It should contain:
>
> - High-level description of the changes
> - Any other things you think matter
